### PR TITLE
Handle non-img files

### DIFF
--- a/app/admin/controllers.py
+++ b/app/admin/controllers.py
@@ -302,8 +302,7 @@ def upload():
 
                 return jsonify({"filelink": "/admin/file_serve/" + blob_key,
                                 "filegallery": img_gallery,
-                                "filename": "" + blob_info.filename,
-                                "thumb": get_serving_url(blob_key, crop=True, size=200)})
+                                "filename": "" + blob_info.filename})
             except Exception as e:
                 logging.exception(e)
                 return jsonify({"error": e})

--- a/app/admin/static/js/upload.js
+++ b/app/admin/static/js/upload.js
@@ -110,19 +110,23 @@
         function addPrevisualization(file){
             var wrapper = nextByClass(dropArea, 'grid');
 
-            //Create wrapper if doesn't exist
-            if (!wrapper){
-                dropArea.insertAdjacentHTML('afterend','<div class="grid"></div>');
-                wrapper = nextByClass(dropArea, 'grid');
-            }
-
             // Check if formInput
             if(formInput){
                 addURLToForm(file);
             }
 
-            // Append the element
-            wrapper.insertAdjacentHTML('beforeEnd', '<div class="grid-item uploaded" style="background-image: url('+file.thumb+');"></div>');
+            if (typeof file.thumb != 'undefined') {
+                //Create wrapper if doesn't exist
+                if (!wrapper){
+                    dropArea.insertAdjacentHTML('afterend','<div class="grid"></div>');
+                    wrapper = nextByClass(dropArea, 'grid');
+                }
+
+                // Append the element
+                wrapper.insertAdjacentHTML('beforeEnd', '<div class="grid-item uploaded" style="background-image: url('+file.thumb+');"></div>');
+            } else {
+                console.log('file has no thumb, skipping previsualization...');
+            }
 
             // Check if all uploaded
             if (totalFiles === 0){
@@ -160,7 +164,11 @@
                         nextElement.removeChild(previousPhoto);
                     }
                 }
-                formInput.value = file.thumb;
+                if (typeof file.thumb == 'undefined') {
+                    formInput.value = file.filelink;
+                } else {
+                    formInput.value = file.thumb;
+                }
             }
         }
 
@@ -227,5 +235,17 @@
             fileInput.addEventListener('change', fileSelectHandler);
 
         }
+
+        // Check if previous value
+        if (formInput.value){
+            var wrapper = nextByClass(dropArea, 'grid');
+            //Create wrapper if doesn't exist
+            if (!wrapper){
+                dropArea.insertAdjacentHTML('afterend','<div class="grid"></div>');
+                wrapper = nextByClass(dropArea, 'grid');
+            }
+            wrapper.insertAdjacentHTML('beforeEnd', '<div class="grid-item" style="background-image: url('+formInput.value+');"></div>');
+        }
     }
+
 })();


### PR DESCRIPTION
No he encontrado ninguna manera de indicar que lo que quiero subir es algo distinto de una imagen. Aparentemente el sistema lo detecta de forma automáticamente, pero no lo está haciendo porque aunque lo que detecte sea distinto de una imagen, intenta hacerlo un thumb y usar su link... He hecho que no intente crear este thumb si lo que estás subiendo un archivo. En el js, he hecho que detecte si el objecto file devuelto tiene thumb. En caso de no tenerlo, no intenta cargar una previsualización y mete como valor del input el link al archivo, en lugar del link al (inexistente) thumb.
